### PR TITLE
Move snyk to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "index.js"
   ],
   "dependencies": {
-    "gm": "1.23.1",
+    "gm": "1.23.1"
+  },
+  "devDependencies": {
     "snyk": "1.147.4"
   },
   "scripts": {


### PR DESCRIPTION
Users should not have to install snyk, as this package is only used in the prepublish step (in development). So I moved it from `dependencies` to `devDependencies`.

Also, thanks for the handy package! (Also, I see that you're using `standard`, nice! I'm the maintainer ✨)