### PR TITLE
Fixing issue with transparent PNG background not getting set to white.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,14 @@ module.exports = class ImageminGm {
         return Promise.reject(new TypeError('Expected a buffer'))
       }
 
-      let image = this.gm(buf).resize(opts.width, opts.height)
+      let image;
+
+      // Disable upscaling the image
+      if(opts.upscale) {
+        image = this.gm(buf).resize(opts.width, opts.height);
+      } else {
+        image = this.gm(buf).resize(opts.width, opts.height, ">")
+      }
 
       if (opts.gravity) {
         image = image.gravity(opts.gravity)

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = class ImageminGm {
           }
 
           // Make sure transparent PNGs get a white background when converted to JPG
-          if (format === 'JPG') {
+          if (format === 'PNG') {
             image = image
               // Compression level is adjusted later in the process
               .quality(100)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagemin-gm",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "GraphicsMagick imagemin plugin",
   "main": "index.js",
   "author": "Frederic Hemberger (https://frederic-hemberger.de/)",


### PR DESCRIPTION
Looks like this should be PNG rather than JPG. I noticed that when resizing and optimizing some transparent PNGs the background was getting set to black rather than white. 